### PR TITLE
Refactors board desserialization

### DIFF
--- a/src/peg/Board.ts
+++ b/src/peg/Board.ts
@@ -1,63 +1,61 @@
-type Position = 'FREE' | 'PEG' | 'BLOCKED';
+export type Position = "FREE" | "PEG" | "BLOCKED";
+type TileTypes = "F" | "P" | "B";
+type TyleTypesObject = {
+  [key in TileTypes]: Position;
+};
 
-type Board = {
-    lines: number,
-    columns: number,
-    t: Position[][]
+export type Board = {
+  rows: number;
+  columns: number;
+  tiles: Position[][];
+};
+
+type TileModel = {
+  size: {
+    columns: number;
+    rows: number;
+  };
+  tiles: string;
+};
+
+const tileTypes: TyleTypesObject = {
+  F: "FREE",
+  P: "PEG",
+  B: "BLOCKED",
+};
+
+const convertLetterToType = (substring: string) =>
+  tileTypes[substring as TileTypes] + "|";
+
+function desserializeBoard(model: TileModel): Board {
+  const { rows, columns } = model.size;
+
+  const tilesTypesString = model.tiles
+    .replaceAll(/[A-Z]/g, convertLetterToType)
+    .split("|");
+
+  const tilesArray: Position[][] = [];
+
+  for (let i = 0; i < columns * rows; i += columns) {
+    tilesArray.push(tilesTypesString.slice(i, i + columns) as Position[]);
+  }
+
+  return {
+    rows,
+    columns,
+    tiles: tilesArray,
+  };
 }
 
-function char2Position(ch: string): Position {
-    switch (ch) {
-        case 'F': return 'FREE';
-        case 'P': return 'PEG';
-        case 'B':
-        default:
-            return 'BLOCKED';
-    }
+export function createBoard(model?: TileModel): Board {
+  if (!model) {
+    model = {
+      size: {
+        rows: 7,
+        columns: 7,
+      },
+      tiles: "BBPPPBBBBPPPBBPPPPPPPPPPFPPPPPPPPPPBBPPPBBBBPPPBB",
+    };
+  }
+  return desserializeBoard(model);
 }
-
-function desserializeBoard(s: string): Board {
-    const fragments = s.split('_');
-    const lines = Number.parseInt(fragments[0]);
-    const columns = Number.parseInt(fragments[1]);
-    const t: Position[][] = [];
-    const stringLen = fragments[2].length;
-    const expectedLen = lines * columns;
-    console.log({lines, columns, fragments})
-    for (let i = 0; i < Math.min(stringLen, expectedLen); i++) {
-        const ch = fragments[2][i];
-        const c = i % columns;
-        const l = Math.floor((i-c)/columns);
-        console.log({i, l, c, t, len: t.length})
-        if (t.length <= l) t.push([])
-        t[l][c] = char2Position(ch);
-    }
-    for (let i = expectedLen; i < stringLen; i++) {
-        const c = i % columns;
-        const l = Math.floor((i-c)/columns);
-        if (t.length <= l) t.push([])
-        t[l][c] = 'BLOCKED';
-    }
-    return {
-        lines,
-        columns,
-        t
-    }
-}
-
-function createBoard(modelo?: string): Board {
-    if (!modelo) {
-        modelo = '7_7_BBPPPBB' +
-                     'BBPPPBB' +
-                     'PPPPPPP' +
-                     'PPPFPPP' +
-                     'PPPPPPP' +
-                     'BBPPPBB' +
-                     'BBPPPBB';
-    }
-    return desserializeBoard(modelo);
-}
-
-export { createBoard };
-export type { Board, Position };
-

--- a/src/peg/Game.tsx
+++ b/src/peg/Game.tsx
@@ -54,7 +54,7 @@ function Gameboard({board}: GameboardProp) {
     const [activePosition, setActivePosition] = useState<ClickablePosition>()
     function apenasAlteraTab(clickedHere: ClickablePosition): { newBoard: Board, activePos?: ClickablePosition} {
         const {x, y} = clickedHere
-        const whereClicked = myBoard.t[x][y];
+        const whereClicked = myBoard.tiles[x][y];
         console.log(`clicked on ${whereClicked}`)
         if (whereClicked === 'BLOCKED') {
             return { newBoard: myBoard }
@@ -72,8 +72,8 @@ function Gameboard({board}: GameboardProp) {
         const newBoard = { ...myBoard};
 
         function move(origin: ClickablePosition, half: ClickablePosition, dest: ClickablePosition) {
-            newBoard.t[origin.x][origin.y] = newBoard.t[half.x][half.y] = 'FREE'
-            newBoard.t[dest.x][dest.y] = 'PEG'
+            newBoard.tiles[origin.x][origin.y] = newBoard.tiles[half.x][half.y] = 'FREE'
+            newBoard.tiles[dest.x][dest.y] = 'PEG'
         }
         if (x === actX) { // same line click
             let halfY: number|null;
@@ -86,7 +86,7 @@ function Gameboard({board}: GameboardProp) {
             }
 
             if (halfY != null) {
-                if (myBoard.t[x][halfY] === 'PEG') {
+                if (myBoard.tiles[x][halfY] === 'PEG') {
                     move(oldPos, {x, y: halfY}, clickedHere);
                 }
             }
@@ -102,7 +102,7 @@ function Gameboard({board}: GameboardProp) {
             }
 
             if (halfX != null) {
-                if (myBoard.t[halfX][y] === 'PEG') {
+                if (myBoard.tiles[halfX][y] === 'PEG') {
                     console.log("at last a valida move")
                     move(oldPos, {x: halfX, y}, clickedHere);
                 }
@@ -140,7 +140,7 @@ function Gameboard({board}: GameboardProp) {
     return <table className={styles.game}>
         <tbody>
         {
-            myBoard.t.map((line, i) => <GameboardLine p={i} line={line} clicked={clicked} key={i}/>)
+            myBoard.tiles.map((line, i) => <GameboardLine p={i} line={line} clicked={clicked} key={i}/>)
         }
         </tbody>
     </table>


### PR DESCRIPTION
Instead of using two fors and generating a matrix by hand, it now works this way:
- uses regex to parse peg types:
```
PPBB --> PEG|PEG|BLOCKED|BLOCKED
```
- splits the string, so it becomes an array:
```
PEG|PEG|BLOCKED|BLOCKED --> ['PEG', 'PEG', 'BLOCKED', 'BLOCKED']
```
- since the splitted array is linear, we need to turn it into a matrix for columns and rows. the code runs a for loop, and creates an array for every column. (Lets suppose we have 2 columns here:)
```js
['PEG', 'PEG', 'BLOCKED', 'BLOCKED'] --> [ ['PEG', 'PEG'], ['BLOCKED', 'BLOCKED'] ]
```
- And after that the tiles are done, and it returns

\* PR also changes Model type, from `t` to `tiles`